### PR TITLE
uses CFBundleVersion for bundleVersion

### DIFF
--- a/RMStore/Optional/RMStoreAppReceiptVerificator.m
+++ b/RMStore/Optional/RMStoreAppReceiptVerificator.m
@@ -69,7 +69,7 @@ static NSString *RMErroDomainStoreAppReceiptVerificator = @"RMStoreAppReceiptVer
 {
     if (!_bundleVersion)
     {
-        return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+        return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
     }
     return _bundleVersion;
 }


### PR DESCRIPTION
**ASN.1 Field Type** 3
**ASN.1 Field Value** UTF8STRING
**JSON Field Name** application_version
**JSON Field Value** string

This corresponds to the value of _CFBundleVersion_ (in **iOS**) or CFBundleShortVersionString (in OS X) in the Info.plist file when the purchase was originally made.

In the sandbox environment, the value of this field is always “1.0”.

[Source](https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW1)
