### PR TITLE
Absolute path fix

### DIFF
--- a/RMStore.xcodeproj/project.pbxproj
+++ b/RMStore.xcodeproj/project.pbxproj
@@ -590,7 +590,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Users/hpique/workspace/RMStore/RMStore/Optional/openssl-1.0.1e/lib",
+					"RMStore/Optional/openssl-1.0.1e/lib",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -611,7 +611,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Users/hpique/workspace/RMStore/RMStore/Optional/openssl-1.0.1e/lib",
+					"RMStore/Optional/openssl-1.0.1e/lib",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Library target doesn't compile because of an absolute path in the settings. Fixed in this commit.
