### PR TITLE
Bug fix: _restoredCompletedTransactionsFinished was never initialised.

### DIFF
--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -226,6 +226,7 @@ typedef void (^RMStoreSuccessBlock)();
 - (void)restoreTransactionsOnSuccess:(RMStoreSuccessBlock)successBlock
                              failure:(RMStoreFailureBlock)failureBlock
 {
+    _restoredCompletedTransactionsFinished = NO;
     _pendingRestoredTransactionsCount = 0;
     _restoreTransactionsSuccessBlock = successBlock;
     _restoreTransactionsFailureBlock = failureBlock;
@@ -237,6 +238,7 @@ typedef void (^RMStoreSuccessBlock)();
                           failure:(void (^)(NSError *error))failureBlock
 {
     NSAssert([[SKPaymentQueue defaultQueue] respondsToSelector:@selector(restoreCompletedTransactionsWithApplicationUsername:)], @"restoreCompletedTransactionsWithApplicationUsername: not supported in this iOS version. Use restoreTransactionsOnSuccess:failure: instead.");
+    _restoredCompletedTransactionsFinished = NO;
     _pendingRestoredTransactionsCount = 0;
     _restoreTransactionsSuccessBlock = successBlock;
     _restoreTransactionsFailureBlock = failureBlock;


### PR DESCRIPTION
First call to `restoreTransactions` worked fine, but the following calls would notify  `RMSKRestoreTransactionsFinished` more than once if more than one transaction is being restored.
