### PR TITLE
Downloadable content support

### DIFF
--- a/RMStore/RMStore.h
+++ b/RMStore/RMStore.h
@@ -235,4 +235,8 @@ extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
  */
 @property (nonatomic, readonly) SKPaymentTransaction *transaction;
 
+/** Used in `storeDownloadFailed`, `storeDownloadUpdate` and `storeDownloadFinished`.
+ */
+@property (nonatomic, readonly) SKDownload *storeDownload;
+
 @end


### PR DESCRIPTION
Notes:
- Commit 0246df1 is a hack to fix an issue with restored transactions. Non-consumable products with downloadable content are some times restored twice. This happens (in the sandbox environment at least) the second time you call `restoreCompletedTransactions` or calling `restoreCompletedTransactions` after buying a different product first.
- The RMStore log _"RMStore: restore transactions finished"_ in the case of downloadable content, shows much earlier than the `storeRestoreTransactionsFinished:` notification call, because the notification is posted once all the downloads are finished. I don't consider it a big issue but I just want to point it out.

This branch would break tests. If you approve the merge I would work on tests and documentation before you do the actual merge.
