### PR TITLE
Fixed null date values by explicitly setting NSDate locale en_US_POSIX

### DIFF
--- a/RMStore/Optional/RMAppReceipt.m
+++ b/RMStore/Optional/RMAppReceipt.m
@@ -313,6 +313,7 @@ static NSURL *_appleRootCertificateURL = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         formatter = [[NSDateFormatter alloc] init];
+        [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
         formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZ";
     });
     NSDate *date = [formatter dateFromString:string];


### PR DESCRIPTION
In RMAppReceipt.m file, the +(NSDate)formatRFC3339String:(NSString)string method

the dateFormat is incompatible with certain settings, example:

If the phone region format setting (General > International > Region Format) is changed to United Kingdom, and the 24-Hour Time Switch is turned off (General > Date & Time).

Because of this, I'm able to get my purchased products' bundle ID, but I cannot get the proper return of NSDate values from [RMAppReceiptIAP originalPurchaseDate], [RMAppReceiptIAP subscriptionExpirationDate], and basically anything that returns a date. It will return me a null value (basically NSDateFormatter failed).

To fix this, I just explicitly set NSDateFormatter locale (In RMAppReceipt formatRFC3339String method) to @"en_US_POSIX" 
Dates are returning as usable values now!

p.s this is my first pull request! just learnt forking and this! everyday u learn something new! :+1:
:baby_bottle: 
