### PR TITLE
Watchdog timer for products request. Observer protocol extension & some minor fixes.

### DIFF
--- a/RMStore/RMStore.h
+++ b/RMStore/RMStore.h
@@ -32,6 +32,10 @@ extern NSInteger const RMStoreErrorCodeUnknownProductIdentifier;
 extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
 extern NSInteger const RMStoreErrorCodeWatchdogTimerFired;
 
+extern NSString* const RMStoreNotificationProductIdentifier;
+extern NSString* const RMStoreNotificationProductsIdentifiers;
+extern NSString* const RMStoreNotificationUserIdentifier;
+
 @class RMStore;
 
 /** Provides watchdog timer functionality to StoreKit response handling classes.
@@ -253,12 +257,16 @@ extern NSInteger const RMStoreErrorCodeWatchdogTimerFired;
 @protocol RMStoreObserver<NSObject>
 @optional
 
+- (void)storePaymentTransactionStarted:(NSNotification*)notification;
 - (void)storePaymentTransactionFailed:(NSNotification*)notification;
 - (void)storePaymentTransactionFinished:(NSNotification*)notification;
+- (void)storeProductsRequestStarted:(NSNotification*)notification;
 - (void)storeProductsRequestFailed:(NSNotification*)notification;
 - (void)storeProductsRequestFinished:(NSNotification*)notification;
+- (void)storeRefreshReceiptStarted __attribute__((availability(ios,introduced=7.0)));
 - (void)storeRefreshReceiptFailed:(NSNotification*)notification __attribute__((availability(ios,introduced=7.0)));
 - (void)storeRefreshReceiptFinished:(NSNotification*)notification __attribute__((availability(ios,introduced=7.0)));
+- (void)storeRestoreTransactionsStarted:(NSNotification*)notification;
 - (void)storeRestoreTransactionsFailed:(NSNotification*)notification;
 - (void)storeRestoreTransactionsFinished:(NSNotification*)notification;
 


### PR DESCRIPTION
About watchdog timer feature.

Watchdog will throw a timeout error in case of network lag on products request. It guarantees fixed time response to customer after his tap on Purchase button for in-app.

I didn't include example in commit but my use case is below.
In my apps after user taps "Purchase" button I show modal activity indicator view then make products request via RMStore. If I've got a products response before watchdog timer fires then there is a big probability that Apple servers will be reachable while payment transaction also. If network is bad I get timeout error from watchdog timer. Then I can choose to dismiss modal activity indicator view and place payment (with network activity indicator as in your example) or show "Try to Retry" message for customer in case of timeout error accordingly.

P.S. Thanks for great library. Keep rocking!
