### PR TITLE
Updated podspec, minimum platform set to 5.0

### DIFF
--- a/RMStore.podspec
+++ b/RMStore.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author = 'Hermes Pique'
   s.social_media_url = 'https://twitter.com/robotmedia'
   s.source = { :git => 'https://github.com/robotmedia/RMStore.git', :tag => "v#{s.version}" }
-  s.platform = :ios, '7.0'
+  s.platform = :ios, '5.0'
   s.frameworks = 'StoreKit'
   s.requires_arc = true
   s.default_subspec = 'Core'


### PR DESCRIPTION
The readme file specifies iOS 5.0 as the minimum supported version but the podspec has 7.0 in it, thus making it impossible to integrate this library in projects targeting older iOS versions.
