### PR TITLE
Rename RMAppReceipt's hash to receiptHash to not clash with NSObject.hash

### DIFF
--- a/RMStore/Optional/RMAppReceipt.h
+++ b/RMStore/Optional/RMAppReceipt.h
@@ -46,7 +46,7 @@ __attribute__((availability(ios,introduced=7.0)))
 
 /** A SHA-1 hash, used to validate the receipt.
  */
-@property (nonatomic, strong, readonly) NSData *hash;
+@property (nonatomic, strong, readonly) NSData *receiptHash;
 
 /** Array of in-app purchases contained in the receipt.
  @see RMAppReceiptIAP

--- a/RMStore/Optional/RMAppReceipt.m
+++ b/RMStore/Optional/RMAppReceipt.m
@@ -127,7 +127,7 @@ static NSURL *_appleRootCertificateURL = nil;
                     _opaqueValue = data;
                     break;
                 case RMAppReceiptASN1TypeHash:
-                    _hash = data;
+                    _receiptHash = data;
                     break;
                 case RMAppReceiptASN1TypeInAppPurchaseReceipt:
                 {
@@ -193,7 +193,7 @@ static NSURL *_appleRootCertificateURL = nil;
     NSMutableData *expectedHash = [NSMutableData dataWithLength:SHA_DIGEST_LENGTH];
     SHA1((const uint8_t*)data.bytes, data.length, (uint8_t*)expectedHash.mutableBytes); // Explicit casting to avoid errors when compiling as Objective-C++
     
-    return [expectedHash isEqualToData:self.hash];
+    return [expectedHash isEqualToData:self.receiptHash];
 }
 
 + (RMAppReceipt*)bundleReceipt

--- a/RMStoreTests/RMAppReceiptTests.m
+++ b/RMStoreTests/RMAppReceiptTests.m
@@ -26,7 +26,7 @@
     STAssertNil(_receipt.bundleIdentifierData, @"");
     STAssertNil(_receipt.appVersion, @"");
     STAssertNil(_receipt.opaqueValue, @"");
-    STAssertNil(_receipt.hash, @"");
+    STAssertNil(_receipt.receiptHash, @"");
     STAssertTrue(_receipt.inAppPurchases.count == 0, @"");
     STAssertNil(_receipt.originalAppVersion, @"");
     STAssertNil(_receipt.expirationDate, @"");


### PR DESCRIPTION
This fixes building against iOS 8.0 beta 4 after changes to NSObject.h:
https://developer.apple.com/library/prerelease/ios/releasenotes/General/iOS80APIDiffs/index.html
