### PR TITLE
Do not log if DEBUG != 1

### DIFF
--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -48,7 +48,7 @@ NSString* const RMStoreNotificationStoreError = @"storeError";
 NSString* const RMStoreNotificationStoreReceipt = @"storeReceipt";
 NSString* const RMStoreNotificationTransaction = @"transaction";
 
-#if defined(DEBUG) && DEBUG
+#if DEBUG
 #define RMStoreLog(...) NSLog(@"RMStore: %@", [NSString stringWithFormat:__VA_ARGS__]);
 #else
 #define RMStoreLog(...)


### PR DESCRIPTION
We might define `DEBUG` to be 0, to disable it. This explicitly requires that `DEBUG` be defined and 1.
