### PR TITLE
Workaround for nil productIdentifier in jailbroken devices

### DIFF
--- a/RMStore/Optional/RMStoreUserDefaultsPersistence.m
+++ b/RMStore/Optional/RMStoreUserDefaultsPersistence.m
@@ -41,7 +41,10 @@ NSString* const RMStoreTransactionsUserDefaultsKey = @"RMStoreTransactions";
     RMStoreTransaction *transaction = [[RMStoreTransaction alloc] initWithPaymentTransaction:paymentTransaction];
     NSData *data = [self dataWithTransaction:transaction];
     [updatedTransactions addObject:data];
-    [self setTransactions:updatedTransactions forProductIdentifier:productIdentifier];
+    
+    if (productIdentifier) {
+        [self setTransactions:updatedTransactions forProductIdentifier:productIdentifier];
+    }
 }
 
 #pragma mark - Public


### PR DESCRIPTION
see http://stackoverflow.com/questions/19817130/following-in-app-purchase-app-crashing-on-startup-productidentifier-nil for the complete info on the issue. a nil if statement resolve the issue

crash log for RMStore:

```
Thread : Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x000000018188f100 __exceptionPreprocess + 132
1  libobjc.A.dylib                0x000000018dd981fc objc_exception_throw + 60
2  CoreFoundation                 0x0000000181796010 -[__NSDictionaryM setObject:forKey:] + 900
3  xxxx        0x000000010037421c -[RMStoreUserDefaultsPersistence setTransactions:forProductIdentifier:] (RMStoreUserDefaultsPersistence.m:143)
4  xxxx        0x0000000100373644 -[RMStoreUserDefaultsPersistence persistTransaction:] (RMStoreUserDefaultsPersistence.m:44)
5  xxxx        0x0000000100371f08 -[RMStore finishTransaction:queue:] (RMStore.m:615)
6  xxxx        0x0000000100371e10 -[RMStore didDownloadSelfHostedContentForTransaction:queue:] (RMStore.m:606)
7  xxxx        0x00000001003719c4 -[RMStore didVerifyTransaction:queue:] (RMStore.m:592)
8  xxxx        0x0000000100371170 -[RMStore didPurchaseTransaction:queue:] (RMStore.m:524)
9  Flex.dylib                     0x000000010073ca7c flexAdvancedForwarding + 160
10 StoreKit                       0x00000001847c511c __NotifyObserverAboutChanges + 112
11 CoreFoundation                 0x000000018178d790 CFArrayApplyFunction + 68
12 StoreKit                       0x00000001847c508c -[SKPaymentQueue _notifyObserversAboutChanges:sendUpdatedDownloads:] + 164
13 StoreKit                       0x00000001847c5c68 -[SKPaymentQueue _processUpdates:trimUnmatched:sendUpdatedDownloads:] + 1328
14 StoreKit                       0x00000001847c6530 -[SKPaymentQueue _setTransactionsWithReply:] + 208
15 StoreKit                       0x00000001847c4aac __38-[SKPaymentQueue _establishConnection]_block_invoke_2 + 68
16 libdispatch.dylib              0x000000018e370014 _dispatch_call_block_and_release + 24
17 libdispatch.dylib              0x000000018e36ffd4 _dispatch_client_callout + 16
18 libdispatch.dylib              0x000000018e3731dc _dispatch_main_queue_callback_4CF + 336
19 CoreFoundation                 0x000000018184eddc __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
20 CoreFoundation                 0x000000018184d11c __CFRunLoopRun + 1452
21 CoreFoundation                 0x000000018178ddd0 CFRunLoopRunSpecific + 452
22 GraphicsServices               0x0000000187475c0c GSEventRunModal + 168
23 UIKit                          0x00000001848befc4 UIApplicationMain + 1156
24 xxxx        0x0000000100148a70 main (main.m:16)
25 libdyld.dylib                  0x000000018e38baa0 start + 4

```