### PR TITLE
Add check for iOS SDK 8.0

### DIFF
--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -370,9 +370,11 @@ typedef void (^RMStoreSuccessBlock)();
             case SKPaymentTransactionStateRestored:
                 [self didRestoreTransaction:transaction queue:queue];
                 break;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
             case SKPaymentTransactionStateDeferred:
                 [self didDeferTransaction:transaction];
                 break;
+#endif
             default:
                 break;
         }


### PR DESCRIPTION
The use of `SKPaymentTransactionStateDeferred` results in a failed build in Xcode 5, since it was introduced in iOS SDK 8.0.

This check excludes `SKPaymentTransactionStateDeferred` from the switch statement when building against a lower SDK.
