### PR TITLE
'strong' attibutes replaced with 'copy' in block properties

### DIFF
--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -108,16 +108,16 @@ typedef void (^RMStoreSuccessBlock)();
 
 @interface RMProductsRequestDelegate : NSObject<SKProductsRequestDelegate>
 
-@property (nonatomic, strong) RMSKProductsRequestSuccessBlock successBlock;
-@property (nonatomic, strong) RMSKProductsRequestFailureBlock failureBlock;
+@property (nonatomic, copy) RMSKProductsRequestSuccessBlock successBlock;
+@property (nonatomic, copy) RMSKProductsRequestFailureBlock failureBlock;
 @property (nonatomic, weak) RMStore *store;
 
 @end
 
 @interface RMAddPaymentParameters : NSObject
 
-@property (nonatomic, strong) RMSKPaymentTransactionSuccessBlock successBlock;
-@property (nonatomic, strong) RMSKPaymentTransactionFailureBlock failureBlock;
+@property (nonatomic, copy) RMSKPaymentTransactionSuccessBlock successBlock;
+@property (nonatomic, copy) RMSKPaymentTransactionFailureBlock failureBlock;
 
 @end
 

--- a/RMStoreTests/RMProducstRequestDelegateTests.m
+++ b/RMStoreTests/RMProducstRequestDelegateTests.m
@@ -25,8 +25,8 @@ typedef void (^RMSKProductsRequestSuccessBlock)(NSArray *products, NSArray *inva
 
 @interface RMProductsRequestDelegate : NSObject<SKProductsRequestDelegate>
 
-@property (nonatomic, strong) RMSKProductsRequestSuccessBlock successBlock;
-@property (nonatomic, strong) RMSKProductsRequestFailureBlock failureBlock;
+@property (nonatomic, copy) RMSKProductsRequestSuccessBlock successBlock;
+@property (nonatomic, copy) RMSKProductsRequestFailureBlock failureBlock;
 @property (nonatomic, weak) RMStore *store;
 
 @end


### PR DESCRIPTION
I've replaced "strong" attribute with "copy" in block properties. 

"Note: You should specify copy as the property attribute, because a block needs to be copied to keep track of its captured state outside of the original scope. This isn’t something you need to worry about when using Automatic Reference Counting, as it will happen automatically, but it’s best practice for the property attribute to show the resultant behavior. For more information, see Blocks Programming Topics."

https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/WorkingwithBlocks/WorkingwithBlocks.html