### PR TITLE
Call finishTransaction only after observers have been notified

### DIFF
--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -632,7 +632,6 @@ typedef void (^RMStoreSuccessBlock)();
 {
     SKPayment *payment = transaction.payment;
 	NSString* productIdentifier = payment.productIdentifier;
-    [queue finishTransaction:transaction];
     [self.transactionPersistor persistTransaction:transaction];
     
     RMAddPaymentParameters *wrapper = [self popAddPaymentParametersForIdentifier:productIdentifier];
@@ -647,6 +646,8 @@ typedef void (^RMStoreSuccessBlock)();
     {
         [self notifyRestoreTransactionFinishedIfApplicableAfterTransaction:transaction];
     }
+    
+    [queue finishTransaction:transaction];
 }
 
 - (void)notifyRestoreTransactionFinishedIfApplicableAfterTransaction:(SKPaymentTransaction*)transaction


### PR DESCRIPTION
The documentation states that: "Your application should call finishTransaction: only after it has successfully processed the transaction and unlocked the functionality purchased by the user."

My interpretation of this is that if the app were to crash somewhere in the process of trying to unlock functionality or saving app state, the transaction should not be marked as finished. That way the app will be able to process the transaction again next time it runs.
