### PR TITLE
Verification failed with app in production. 

### DIFF
--- a/RMStore/Optional/RMStoreAppReceiptVerificator.m
+++ b/RMStore/Optional/RMStoreAppReceiptVerificator.m
@@ -61,7 +61,11 @@
 {
     if (!_bundleVersion)
     {
+#if TARGET_OS_IPHONE
+        return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+#else
         return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+#endif
     }
     return _bundleVersion;
 }

--- a/RMStore/Optional/RMStoreAppReceiptVerificator.m
+++ b/RMStore/Optional/RMStoreAppReceiptVerificator.m
@@ -61,7 +61,7 @@
 {
     if (!_bundleVersion)
     {
-        return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+        return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     }
     return _bundleVersion;
 }


### PR DESCRIPTION
The app version mismatched the bundle version. By using short sting we are checking for the correct app version.

Issue:https://github.com/robotmedia/RMStore/issues/58
Info about the change: http://stackoverflow.com/questions/6876923/difference-between-xcode-version-cfbundleshortversionstring-and-build-cfbundl