### PR TITLE
Fix to ensure restoreTransactions completion callback is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 #RMStore
 
-[![Join the chat at https://gitter.im/robotmedia/RMStore](https://badges.gitter.im/robotmedia/RMStore.svg)](https://gitter.im/robotmedia/RMStore?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Version](https://cocoapod-badges.herokuapp.com/v/RMStore/badge.png)](http://cocoadocs.org/docsets/RMStore) [![Platform](https://cocoapod-badges.herokuapp.com/p/RMStore/badge.png)](http://cocoadocs.org/docsets/RMStore)
+[![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/RMStore/badge.png)](http://cocoadocs.org/docsets/RMStore) [![Platform](https://cocoapod-badges.herokuapp.com/p/RMStore/badge.png)](http://cocoadocs.org/docsets/RMStore)
 [![Build Status](https://travis-ci.org/robotmedia/RMStore.png)](https://travis-ci.org/robotmedia/RMStore)
+[![Join the chat at https://gitter.im/robotmedia/RMStore](https://badges.gitter.im/robotmedia/RMStore.svg)](https://gitter.im/robotmedia/RMStore?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A lightweight iOS library for In-App Purchases.
 

--- a/RMStore.podspec
+++ b/RMStore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'RMStore'
-  s.version = '0.7.1'
+  s.version = '0.7.2'
   s.license = 'Apache 2.0'
   s.summary = 'A lightweight iOS library for In-App Purchases that adds blocks and notifications to StoreKit, plus verification, persistence and downloads.'
   s.homepage = 'https://github.com/robotmedia/RMStore'

--- a/RMStore.podspec
+++ b/RMStore.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name = 'RMStore'
   s.version = '0.7.1'
   s.license = 'Apache 2.0'
-  s.summary = 'A lightweight iOS library for In-App Purchases. RMStore add blocks and notifications to StoreKit, plus receipt verification, content downloads and transaction persistence.'
+  s.summary = 'A lightweight iOS library for In-App Purchases that adds blocks and notifications to StoreKit, plus verification, persistence and downloads.'
   s.homepage = 'https://github.com/robotmedia/RMStore'
   s.author = 'Hermes Pique'
   s.social_media_url = 'https://twitter.com/hpique'

--- a/RMStore.podspec
+++ b/RMStore.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/robotmedia/RMStore'
   s.author = 'Hermes Pique'
   s.social_media_url = 'https://twitter.com/hpique'
-  s.source = { :git => 'https://github.com/robotmedia/RMStore.git', :tag => "v#{s.version}" }
+  s.source = { :git => 'https://bitbucket.org/ipnossoft/pod-rm-store.git', :tag => "v#{s.version}" }
   s.platform = :ios, '7.0'
   s.frameworks = 'StoreKit'
   s.requires_arc = true

--- a/RMStore.podspec
+++ b/RMStore.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name = 'RMStore'
-  s.version = '0.7.2'
+  s.version = '0.7.1'
   s.license = 'Apache 2.0'
-  s.summary = 'A lightweight iOS library for In-App Purchases that adds blocks and notifications to StoreKit, plus verification, persistence and downloads.'
+  s.summary = 'A lightweight iOS library for In-App Purchases. RMStore add blocks and notifications to StoreKit, plus receipt verification, content downloads and transaction persistence.'
   s.homepage = 'https://github.com/robotmedia/RMStore'
   s.author = 'Hermes Pique'
   s.social_media_url = 'https://twitter.com/hpique'
-  s.source = { :git => 'https://bitbucket.org/ipnossoft/pod-rm-store.git', :tag => "v#{s.version}" }
+  s.source = { :git => 'https://github.com/robotmedia/RMStore.git', :tag => "v#{s.version}" }
   s.platform = :ios, '7.0'
   s.frameworks = 'StoreKit'
   s.requires_arc = true

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -136,7 +136,7 @@ typedef void (^RMStoreSuccessBlock)();
 
     NSMutableArray *_restoredTransactions;
 
-    NSMutableSet *_pendingRestoredTransactionsCount;
+    NSMutableSet *_pendingRestoredTransactionIds;
     BOOL _restoredCompletedTransactionsFinished;
 
     SKReceiptRefreshRequest *_refreshReceiptRequest;
@@ -155,7 +155,7 @@ typedef void (^RMStoreSuccessBlock)();
         _products = [NSMutableDictionary dictionary];
         _productsRequestDelegates = [NSMutableSet set];
         _restoredTransactions = [NSMutableArray array];
-        _pendingRestoredTransactionsCount = [NSMutableSet set];
+        _pendingRestoredTransactionIds = [NSMutableSet set];
         [[SKPaymentQueue defaultQueue] addTransactionObserver:self];
     }
     return self;
@@ -255,7 +255,7 @@ typedef void (^RMStoreSuccessBlock)();
         failure:(void (^)(NSError *error))failureBlock
 {
     _restoredCompletedTransactionsFinished = NO;
-    [_pendingRestoredTransactionsCount removeAllObjects];
+    [_pendingRestoredTransactionIds removeAllObjects];
     _restoredTransactions = [NSMutableArray array];
     _restoreTransactionsSuccessBlock = successBlock;
     _restoreTransactionsFailureBlock = failureBlock;
@@ -268,7 +268,7 @@ typedef void (^RMStoreSuccessBlock)();
 {
     NSAssert([[SKPaymentQueue defaultQueue] respondsToSelector:@selector(restoreCompletedTransactionsWithApplicationUsername:)], @"restoreCompletedTransactionsWithApplicationUsername: not supported in this iOS version. Use restoreTransactionsOnSuccess:failure: instead.");
     _restoredCompletedTransactionsFinished = NO;
-    [_pendingRestoredTransactionsCount removeAllObjects];
+    [_pendingRestoredTransactionIds removeAllObjects];
     _restoreTransactionsSuccessBlock = successBlock;
     _restoreTransactionsFailureBlock = failureBlock;
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactionsWithApplicationUsername:userIdentifier];
@@ -573,7 +573,9 @@ typedef void (^RMStoreSuccessBlock)();
     NSString *productIdentifier = transaction.originalTransaction.payment.productIdentifier;
     RMStoreLog(@"transaction restored with product %@", productIdentifier);
 
-    [_pendingRestoredTransactionsCount addObject:productIdentifier];
+    if(productIdentifier) {
+        [_pendingRestoredTransactionIds addObject:productIdentifier];
+    }
     if (self.receiptVerificator != nil)
     {
         [self.receiptVerificator verifyTransaction:transaction success:^{
@@ -656,9 +658,9 @@ typedef void (^RMStoreSuccessBlock)();
     if (transaction != nil)
     {
         [_restoredTransactions addObject:transaction];
-        [_pendingRestoredTransactionsCount removeObject:transaction.payment.productIdentifier];
+        [_pendingRestoredTransactionIds removeObject:transaction.payment.productIdentifier];
     }
-    if (_restoredCompletedTransactionsFinished && _pendingRestoredTransactionsCount.count == 0)
+    if (_restoredCompletedTransactionsFinished && _pendingRestoredTransactionIds.count == 0)
     { // Wait until all restored transations have been verified
         NSArray *restoredTransactions = [_restoredTransactions copy];
         if (_restoreTransactionsSuccessBlock != nil)

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -559,7 +559,6 @@ typedef void (^RMStoreSuccessBlock)();
 
     NSDictionary *extras = error ? @{RMStoreNotificationStoreError : error} : nil;
     [self postNotificationWithName:RMSKPaymentTransactionFailed transaction:transaction userInfoExtras:extras];
-
     if (transaction.transactionState == SKPaymentTransactionStateRestored)
     {
         [self notifyRestoreTransactionFinishedIfApplicableAfterTransaction:transaction];
@@ -759,7 +758,6 @@ typedef void (^RMStoreSuccessBlock)();
     [invalidProductIdentifiers enumerateObjectsUsingBlock:^(NSString *invalid, NSUInteger idx, BOOL *stop) {
         RMStoreLog(@"invalid product with id %@", invalid);
     }];
-
     if (self.successBlock)
     {
         self.successBlock(products, invalidProductIdentifiers);

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -133,16 +133,12 @@ typedef void (^RMStoreSuccessBlock)();
     NSMutableDictionary *_addPaymentParameters; // HACK: We use a dictionary of product identifiers because the returned SKPayment is different from the one we add to the queue. Bad Apple.
     NSMutableDictionary *_products;
     NSMutableSet *_productsRequestDelegates;
-
     NSMutableArray *_restoredTransactions;
-
     NSMutableSet *_pendingRestoredTransactionIds;
     BOOL _restoredCompletedTransactionsFinished;
-
     SKReceiptRefreshRequest *_refreshReceiptRequest;
     void (^_refreshReceiptFailureBlock)(NSError* error);
     void (^_refreshReceiptSuccessBlock)();
-
     void (^_restoreTransactionsFailureBlock)(NSError* error);
     void (^_restoreTransactionsSuccessBlock)(NSArray* transactions);
 }
@@ -216,12 +212,10 @@ typedef void (^RMStoreSuccessBlock)();
     {
         payment.applicationUsername = userIdentifier;
     }
-
     RMAddPaymentParameters *parameters = [[RMAddPaymentParameters alloc] init];
     parameters.successBlock = successBlock;
     parameters.failureBlock = failureBlock;
     _addPaymentParameters[productIdentifier] = parameters;
-
     [[SKPaymentQueue defaultQueue] addPayment:payment];
 }
 
@@ -239,10 +233,8 @@ typedef void (^RMStoreSuccessBlock)();
     delegate.successBlock = successBlock;
     delegate.failureBlock = failureBlock;
     [_productsRequestDelegates addObject:delegate];
-
     SKProductsRequest *productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:identifiers];
     productsRequest.delegate = delegate;
-
     [productsRequest start];
 }
 
@@ -393,7 +385,6 @@ typedef void (^RMStoreSuccessBlock)();
 {
     RMStoreLog(@"restore transactions finished");
     _restoredCompletedTransactionsFinished = YES;
-
     [self notifyRestoreTransactionFinishedIfApplicableAfterTransaction:nil];
 }
 
@@ -479,7 +470,6 @@ typedef void (^RMStoreSuccessBlock)();
 {
     SKPaymentTransaction *transaction = download.transaction;
     RMStoreLog(@"download %@ for product %@ finished", download.contentIdentifier, transaction.payment.productIdentifier);
-
     [self postNotificationWithName:RMSKDownloadFinished download:download userInfoExtras:nil];
 
     const BOOL hasPendingDownloads = [self.class hasPendingDownloadsInTransaction:transaction];
@@ -526,7 +516,6 @@ typedef void (^RMStoreSuccessBlock)();
 - (void)didPurchaseTransaction:(SKPaymentTransaction *)transaction queue:(SKPaymentQueue*)queue
 {
     RMStoreLog(@"transaction purchased with product %@", transaction.payment.productIdentifier);
-
     if (self.receiptVerificator != nil)
     {
         [self.receiptVerificator verifyTransaction:transaction success:^{
@@ -547,18 +536,15 @@ typedef void (^RMStoreSuccessBlock)();
     SKPayment *payment = transaction.payment;
     NSString* productIdentifier = payment.productIdentifier;
     RMStoreLog(@"transaction failed with product %@ and error %@", productIdentifier, error.debugDescription);
-
     if (error.code != RMStoreErrorCodeUnableToCompleteVerification)
     { // If we were unable to complete the verification we want StoreKit to keep reminding us of the transaction
         [queue finishTransaction:transaction];
     }
-
     RMAddPaymentParameters *parameters = [self popAddPaymentParametersForIdentifier:productIdentifier];
     if (parameters.failureBlock != nil)
     {
         parameters.failureBlock(transaction, error);
     }
-
     NSDictionary *extras = error ? @{RMStoreNotificationStoreError : error} : nil;
     [self postNotificationWithName:RMSKPaymentTransactionFailed transaction:transaction userInfoExtras:extras];
 
@@ -572,7 +558,6 @@ typedef void (^RMStoreSuccessBlock)();
 {
     NSString *productIdentifier = transaction.originalTransaction.payment.productIdentifier;
     RMStoreLog(@"transaction restored with product %@", productIdentifier);
-
     if(productIdentifier) {
         [_pendingRestoredTransactionIds addObject:productIdentifier];
     }
@@ -638,15 +623,12 @@ typedef void (^RMStoreSuccessBlock)();
     NSString* productIdentifier = payment.productIdentifier;
     [queue finishTransaction:transaction];
     [self.transactionPersistor persistTransaction:transaction];
-
     RMAddPaymentParameters *wrapper = [self popAddPaymentParametersForIdentifier:productIdentifier];
     if (wrapper.successBlock != nil)
     {
         wrapper.successBlock(transaction);
     }
-
     [self postNotificationWithName:RMSKPaymentTransactionFinished transaction:transaction userInfoExtras:nil];
-
     if (transaction.transactionState == SKPaymentTransactionStateRestored)
     {
         [self notifyRestoreTransactionFinishedIfApplicableAfterTransaction:transaction];
@@ -752,13 +734,11 @@ typedef void (^RMStoreSuccessBlock)();
     RMStoreLog(@"products request received response");
     NSArray *products = [NSArray arrayWithArray:response.products];
     NSArray *invalidProductIdentifiers = [NSArray arrayWithArray:response.invalidProductIdentifiers];
-
     for (SKProduct *product in products)
     {
         RMStoreLog(@"received product with id %@", product.productIdentifier);
         [self.store addProduct:product];
     }
-
     [invalidProductIdentifiers enumerateObjectsUsingBlock:^(NSString *invalid, NSUInteger idx, BOOL *stop) {
         RMStoreLog(@"invalid product with id %@", invalid);
     }];

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -547,7 +547,6 @@ typedef void (^RMStoreSuccessBlock)();
     }
     NSDictionary *extras = error ? @{RMStoreNotificationStoreError : error} : nil;
     [self postNotificationWithName:RMSKPaymentTransactionFailed transaction:transaction userInfoExtras:extras];
-
     if (transaction.transactionState == SKPaymentTransactionStateRestored)
     {
         [self notifyRestoreTransactionFinishedIfApplicableAfterTransaction:transaction];
@@ -742,7 +741,6 @@ typedef void (^RMStoreSuccessBlock)();
     [invalidProductIdentifiers enumerateObjectsUsingBlock:^(NSString *invalid, NSUInteger idx, BOOL *stop) {
         RMStoreLog(@"invalid product with id %@", invalid);
     }];
-
     if (self.successBlock)
     {
         self.successBlock(products, invalidProductIdentifiers);

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -525,6 +525,7 @@ typedef void (^RMStoreSuccessBlock)();
 - (void)didPurchaseTransaction:(SKPaymentTransaction *)transaction queue:(SKPaymentQueue*)queue
 {
     RMStoreLog(@"transaction purchased with product %@", transaction.payment.productIdentifier);
+
     if (self.receiptVerificator != nil)
     {
         [self.receiptVerifier verifyTransaction:transaction success:^{
@@ -559,6 +560,7 @@ typedef void (^RMStoreSuccessBlock)();
 
     NSDictionary *extras = error ? @{RMStoreNotificationStoreError : error} : nil;
     [self postNotificationWithName:RMSKPaymentTransactionFailed transaction:transaction userInfoExtras:extras];
+
     if (transaction.transactionState == SKPaymentTransactionStateRestored)
     {
         [self notifyRestoreTransactionFinishedIfApplicableAfterTransaction:transaction];
@@ -631,7 +633,7 @@ typedef void (^RMStoreSuccessBlock)();
 - (void)finishTransaction:(SKPaymentTransaction *)transaction queue:(SKPaymentQueue*)queue
 {
     SKPayment *payment = transaction.payment;
-    NSString* productIdentifier = payment.productIdentifier;
+	NSString* productIdentifier = payment.productIdentifier;
     [queue finishTransaction:transaction];
     [self.transactionPersistor persistTransaction:transaction];
 
@@ -758,6 +760,7 @@ typedef void (^RMStoreSuccessBlock)();
     [invalidProductIdentifiers enumerateObjectsUsingBlock:^(NSString *invalid, NSUInteger idx, BOOL *stop) {
         RMStoreLog(@"invalid product with id %@", invalid);
     }];
+
     if (self.successBlock)
     {
         self.successBlock(products, invalidProductIdentifiers);

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -185,16 +185,16 @@ typedef void (^RMStoreSuccessBlock)();
 }
 
 - (void)addPayment:(NSString*)productIdentifier
-        success:(void (^)(SKPaymentTransaction *transaction))successBlock
-        failure:(void (^)(SKPaymentTransaction *transaction, NSError *error))failureBlock
+           success:(void (^)(SKPaymentTransaction *transaction))successBlock
+           failure:(void (^)(SKPaymentTransaction *transaction, NSError *error))failureBlock
 {
     [self addPayment:productIdentifier user:nil success:successBlock failure:failureBlock];
 }
 
 - (void)addPayment:(NSString*)productIdentifier
-        user:(NSString*)userIdentifier
-        success:(void (^)(SKPaymentTransaction *transaction))successBlock
-        failure:(void (^)(SKPaymentTransaction *transaction, NSError *error))failureBlock
+              user:(NSString*)userIdentifier
+           success:(void (^)(SKPaymentTransaction *transaction))successBlock
+           failure:(void (^)(SKPaymentTransaction *transaction, NSError *error))failureBlock
 {
     SKProduct *product = [self productForIdentifier:productIdentifier];
     if (product == nil)
@@ -225,8 +225,8 @@ typedef void (^RMStoreSuccessBlock)();
 }
 
 - (void)requestProducts:(NSSet*)identifiers
-        success:(RMSKProductsRequestSuccessBlock)successBlock
-        failure:(RMSKProductsRequestFailureBlock)failureBlock
+                success:(RMSKProductsRequestSuccessBlock)successBlock
+                failure:(RMSKProductsRequestFailureBlock)failureBlock
 {
     RMProductsRequestDelegate *delegate = [[RMProductsRequestDelegate alloc] init];
     delegate.store = self;
@@ -244,7 +244,7 @@ typedef void (^RMStoreSuccessBlock)();
 }
 
 - (void)restoreTransactionsOnSuccess:(void (^)(NSArray *transactions))successBlock
-        failure:(void (^)(NSError *error))failureBlock
+                             failure:(void (^)(NSError *error))failureBlock
 {
     _restoredCompletedTransactionsFinished = NO;
     [_pendingRestoredTransactionIds removeAllObjects];
@@ -255,8 +255,8 @@ typedef void (^RMStoreSuccessBlock)();
 }
 
 - (void)restoreTransactionsOfUser:(NSString*)userIdentifier
-        onSuccess:(void (^)(NSArray *transactions))successBlock
-        failure:(void (^)(NSError *error))failureBlock
+                        onSuccess:(void (^)(NSArray *transactions))successBlock
+                          failure:(void (^)(NSError *error))failureBlock
 {
     NSAssert([[SKPaymentQueue defaultQueue] respondsToSelector:@selector(restoreCompletedTransactionsWithApplicationUsername:)], @"restoreCompletedTransactionsWithApplicationUsername: not supported in this iOS version. Use restoreTransactionsOnSuccess:failure: instead.");
     _restoredCompletedTransactionsFinished = NO;
@@ -282,7 +282,7 @@ typedef void (^RMStoreSuccessBlock)();
 }
 
 - (void)refreshReceiptOnSuccess:(RMStoreSuccessBlock)successBlock
-        failure:(RMStoreFailureBlock)failureBlock
+                        failure:(RMStoreFailureBlock)failureBlock
 {
     _refreshReceiptFailureBlock = failureBlock;
     _refreshReceiptSuccessBlock = successBlock;

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -526,7 +526,7 @@ typedef void (^RMStoreSuccessBlock)();
 {
     RMStoreLog(@"transaction purchased with product %@", transaction.payment.productIdentifier);
 
-    if (self.receiptVerificator != nil)
+    if (self.receiptVerifier != nil)
     {
         [self.receiptVerifier verifyTransaction:transaction success:^{
             [self didVerifyTransaction:transaction queue:queue];
@@ -569,12 +569,13 @@ typedef void (^RMStoreSuccessBlock)();
 
 - (void)didRestoreTransaction:(SKPaymentTransaction *)transaction queue:(SKPaymentQueue*)queue
 {
-    RMStoreLog(@"transaction restored with product %@", transaction.originalTransaction.payment.productIdentifier);
+    NSString *productIdentifier = transaction.originalTransaction.payment.productIdentifier;
+    RMStoreLog(@"transaction restored with product %@", productIdentifier);
 
     if(productIdentifier) {
         [_pendingRestoredTransactionIds addObject:productIdentifier];
     }
-    if (self.receiptVerificator != nil)
+    if (self.receiptVerifier != nil)
     {
         [self.receiptVerifier verifyTransaction:transaction success:^{
             [self didVerifyTransaction:transaction queue:queue];

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -133,16 +133,15 @@ typedef void (^RMStoreSuccessBlock)();
     NSMutableDictionary *_addPaymentParameters; // HACK: We use a dictionary of product identifiers because the returned SKPayment is different from the one we add to the queue. Bad Apple.
     NSMutableDictionary *_products;
     NSMutableSet *_productsRequestDelegates;
-    
-    NSMutableArray *_restoredTransactions;
 
+    NSMutableArray *_restoredTransactions;
     NSMutableSet *_pendingRestoredTransactionIds;
     BOOL _restoredCompletedTransactionsFinished;
-    
+
     SKReceiptRefreshRequest *_refreshReceiptRequest;
     void (^_refreshReceiptFailureBlock)(NSError* error);
     void (^_refreshReceiptSuccessBlock)();
-    
+
     void (^_restoreTransactionsFailureBlock)(NSError* error);
     void (^_restoreTransactionsSuccessBlock)(NSArray* transactions);
 }
@@ -216,12 +215,12 @@ typedef void (^RMStoreSuccessBlock)();
     {
         payment.applicationUsername = userIdentifier;
     }
-    
+
     RMAddPaymentParameters *parameters = [[RMAddPaymentParameters alloc] init];
     parameters.successBlock = successBlock;
     parameters.failureBlock = failureBlock;
     _addPaymentParameters[productIdentifier] = parameters;
-    
+
     [[SKPaymentQueue defaultQueue] addPayment:payment];
 }
 
@@ -239,10 +238,10 @@ typedef void (^RMStoreSuccessBlock)();
     delegate.successBlock = successBlock;
     delegate.failureBlock = failureBlock;
     [_productsRequestDelegates addObject:delegate];
- 
+
     SKProductsRequest *productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:identifiers];
 	productsRequest.delegate = delegate;
-    
+
     [productsRequest start];
 }
 
@@ -393,7 +392,7 @@ typedef void (^RMStoreSuccessBlock)();
 {
     RMStoreLog(@"restore transactions finished");
     _restoredCompletedTransactionsFinished = YES;
-    
+
     [self notifyRestoreTransactionFinishedIfApplicableAfterTransaction:nil];
 }
 
@@ -479,7 +478,7 @@ typedef void (^RMStoreSuccessBlock)();
 {
     SKPaymentTransaction *transaction = download.transaction;
     RMStoreLog(@"download %@ for product %@ finished", download.contentIdentifier, transaction.payment.productIdentifier);
-    
+
     [self postNotificationWithName:RMSKDownloadFinished download:download userInfoExtras:nil];
 
     const BOOL hasPendingDownloads = [self.class hasPendingDownloadsInTransaction:transaction];
@@ -526,7 +525,6 @@ typedef void (^RMStoreSuccessBlock)();
 - (void)didPurchaseTransaction:(SKPaymentTransaction *)transaction queue:(SKPaymentQueue*)queue
 {
     RMStoreLog(@"transaction purchased with product %@", transaction.payment.productIdentifier);
-
     if (self.receiptVerificator != nil)
     {
         [self.receiptVerifier verifyTransaction:transaction success:^{
@@ -547,21 +545,21 @@ typedef void (^RMStoreSuccessBlock)();
     SKPayment *payment = transaction.payment;
 	NSString* productIdentifier = payment.productIdentifier;
     RMStoreLog(@"transaction failed with product %@ and error %@", productIdentifier, error.debugDescription);
-    
+
     if (error.code != RMStoreErrorCodeUnableToCompleteVerification)
     { // If we were unable to complete the verification we want StoreKit to keep reminding us of the transaction
         [queue finishTransaction:transaction];
     }
-    
+
     RMAddPaymentParameters *parameters = [self popAddPaymentParametersForIdentifier:productIdentifier];
     if (parameters.failureBlock != nil)
     {
         parameters.failureBlock(transaction, error);
     }
-    
+
     NSDictionary *extras = error ? @{RMStoreNotificationStoreError : error} : nil;
     [self postNotificationWithName:RMSKPaymentTransactionFailed transaction:transaction userInfoExtras:extras];
-    
+
     if (transaction.transactionState == SKPaymentTransactionStateRestored)
     {
         [self notifyRestoreTransactionFinishedIfApplicableAfterTransaction:transaction];
@@ -637,15 +635,15 @@ typedef void (^RMStoreSuccessBlock)();
     NSString* productIdentifier = payment.productIdentifier;
     [queue finishTransaction:transaction];
     [self.transactionPersistor persistTransaction:transaction];
-    
+
     RMAddPaymentParameters *wrapper = [self popAddPaymentParametersForIdentifier:productIdentifier];
     if (wrapper.successBlock != nil)
     {
         wrapper.successBlock(transaction);
     }
-    
+
     [self postNotificationWithName:RMSKPaymentTransactionFinished transaction:transaction userInfoExtras:nil];
-    
+
     if (transaction.transactionState == SKPaymentTransactionStateRestored)
     {
         [self notifyRestoreTransactionFinishedIfApplicableAfterTransaction:transaction];
@@ -714,7 +712,7 @@ typedef void (^RMStoreSuccessBlock)();
 
 - (void)addProduct:(SKProduct*)product
 {
-    _products[product.productIdentifier] = product;    
+    _products[product.productIdentifier] = product;
 }
 
 - (void)postNotificationWithName:(NSString*)notificationName download:(SKDownload*)download userInfoExtras:(NSDictionary*)extras
@@ -751,17 +749,17 @@ typedef void (^RMStoreSuccessBlock)();
     RMStoreLog(@"products request received response");
     NSArray *products = [NSArray arrayWithArray:response.products];
     NSArray *invalidProductIdentifiers = [NSArray arrayWithArray:response.invalidProductIdentifiers];
-    
+
     for (SKProduct *product in products)
     {
         RMStoreLog(@"received product with id %@", product.productIdentifier);
         [self.store addProduct:product];
     }
-    
+
     [invalidProductIdentifiers enumerateObjectsUsingBlock:^(NSString *invalid, NSUInteger idx, BOOL *stop) {
         RMStoreLog(@"invalid product with id %@", invalid);
     }];
-    
+
     if (self.successBlock)
     {
         self.successBlock(products, invalidProductIdentifiers);


### PR DESCRIPTION
Inside RMStore, when the paymentQueue:updatedTransactions is called after a restore, a pendingRestoredTransactions counter was incremented/decremented as transactions were processed. However, in our case updateTransactions callback was called twice, so 2x the amount of transactions were added to the pendingRestoredTransactions counter. The problem was the counter was incremented twice but only decremented once for each transaction. WHen the code reached notifyRestoreTransactionFinishedIfApplicableAfterTransaction, the counter was checked but was not equal to zero, so the callback wasn't called, even though all the transactions were processed.

The fix was to use a MutableSet to store transaction identifiers that were pending restore, which prevents duplicate transactions to be handled. The callback is now always called after transactions are restored.
