### PR TITLE
Update RMStore.podspec for AppReceiptVerificator OpenSSL dependency update

### DIFF
--- a/RMStore.podspec
+++ b/RMStore.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
     arv.dependency 'RMStore/Core'
     arv.platform = :ios, '7.0'
     arv.source_files = 'RMStore/Optional/RMStoreAppReceiptVerifier.{h,m}', 'RMStore/Optional/RMAppReceipt.{h,m}'
-    arv.dependency 'OpenSSL', '~> 1.0.1'
+    arv.dependency 'OpenSSL', '~> 1.0'
   end
 
   s.subspec 'TransactionReceiptVerifier' do |trv|


### PR DESCRIPTION
Instead of specifying version 1.0.1.x of OpenSSL, generalize to 1.0.x to include the latest OpenSSL changes that allow iOS 7 compilation in Xcode 7 for projects using the AppReceiptVerificator CocoaPod dependency.