### PR TITLE
Update OpenSSL dependency

### DIFF
--- a/RMStore.podspec
+++ b/RMStore.podspec
@@ -27,11 +27,15 @@ Pod::Spec.new do |s|
     nsudp.source_files = 'RMStore/Optional/RMStoreUserDefaultsPersistence.{h,m}', 'RMStore/Optional/RMStoreTransaction.{h,m}'
   end
 
-  s.subspec 'AppReceiptVerifier' do |arv|
+  s.subspec 'AppReceiptVerificator' do |arv|
     arv.dependency 'RMStore/Core'
     arv.platform = :ios, '7.0'
-    arv.source_files = 'RMStore/Optional/RMStoreAppReceiptVerifier.{h,m}', 'RMStore/Optional/RMAppReceipt.{h,m}'
-    arv.dependency 'OpenSSL', '~> 1.0'
+    arv.source_files = 'RMStore/Optional/RMStoreAppReceiptVerificator.{h,m}', 'RMStore/Optional/RMAppReceipt.{h,m}'
+    arv.dependency 'OpenSSL-iOS'
+
+    arv.vendored_libraries = '${PODS_ROOT}/OpenSSL-iOS/libcrypto.a', '${PODS_ROOT}/OpenSSL-iOS/libssl.a'
+    arv.libraries = 'ssl', 'crypto'
+    arv.xcconfig = { 'HEADER_SEARCH_PATHS' => "${PODS_ROOT}/OpenSSL-iOS/openssl/**", 'LIBRARY_SEARCH_PATHS' => "${PODS_ROOT}/OpenSSL-iOS/" }
   end
 
   s.subspec 'TransactionReceiptVerifier' do |trv|

--- a/RMStore.podspec
+++ b/RMStore.podspec
@@ -27,10 +27,10 @@ Pod::Spec.new do |s|
     nsudp.source_files = 'RMStore/Optional/RMStoreUserDefaultsPersistence.{h,m}', 'RMStore/Optional/RMStoreTransaction.{h,m}'
   end
 
-  s.subspec 'AppReceiptVerificator' do |arv|
+  s.subspec 'AppReceiptVerifier' do |arv|
     arv.dependency 'RMStore/Core'
     arv.platform = :ios, '7.0'
-    arv.source_files = 'RMStore/Optional/RMStoreAppReceiptVerificator.{h,m}', 'RMStore/Optional/RMAppReceipt.{h,m}'
+    arv.source_files = 'RMStore/Optional/RMStoreAppReceiptVerifier.{h,m}', 'RMStore/Optional/RMAppReceipt.{h,m}'
     arv.dependency 'OpenSSL-iOS'
 
     arv.vendored_libraries = '${PODS_ROOT}/OpenSSL-iOS/libcrypto.a', '${PODS_ROOT}/OpenSSL-iOS/libssl.a'


### PR DESCRIPTION
Updated OpenSSL dependency in AppReceiptVerificator to support dynamic frameworks in Swift. Based on the issue here: https://github.com/robotmedia/RMStore/issues/170#issuecomment-186898474
