### PR TITLE
Orphan purchases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 #RMStore
 
-I have changed this.
-
 [![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/RMStore/badge.png)](http://cocoadocs.org/docsets/RMStore) [![Platform](https://cocoapod-badges.herokuapp.com/p/RMStore/badge.png)](http://cocoadocs.org/docsets/RMStore)
 [![Build Status](https://travis-ci.org/robotmedia/RMStore.png)](https://travis-ci.org/robotmedia/RMStore)
 [![Join the chat at https://gitter.im/robotmedia/RMStore](https://badges.gitter.im/robotmedia/RMStore.svg)](https://gitter.im/robotmedia/RMStore?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #RMStore
 
+I have changed this.
+
 [![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/RMStore/badge.png)](http://cocoadocs.org/docsets/RMStore) [![Platform](https://cocoapod-badges.herokuapp.com/p/RMStore/badge.png)](http://cocoadocs.org/docsets/RMStore)
 [![Build Status](https://travis-ci.org/robotmedia/RMStore.png)](https://travis-ci.org/robotmedia/RMStore)
 [![Join the chat at https://gitter.im/robotmedia/RMStore](https://badges.gitter.im/robotmedia/RMStore.svg)](https://gitter.im/robotmedia/RMStore?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/RMStore/RMStore.h
+++ b/RMStore/RMStore.h
@@ -30,7 +30,16 @@ extern NSString *const RMStoreErrorDomain;
 extern NSInteger const RMStoreErrorCodeDownloadCanceled;
 extern NSInteger const RMStoreErrorCodeUnknownProductIdentifier;
 extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
+
+/**
+ This gets posted globally when:
+ Nobody has requested this transaction, which would indicate that the app has died after purchase (or at least sometime after beeing added) but before finishTransaction was called.
+ This regularly happens on older devices if credit cards are denied or old, then the user needs to update their card info and switch away from the app. When coming back the app might have been killed and the success-block is gone (since it was living in RAM).
+ */
 extern NSString* const RMSKPaymentTransactionOrhanFinished;
+
+///Same as RMSKPaymentTransactionOrhanFinished but for failed purchases.
+extern NSString* const RMSKPaymentTransactionOrhanFailed;
 
 /** A StoreKit wrapper that adds blocks and notifications, plus optional receipt verification and purchase management.
  */

--- a/RMStore/RMStore.h
+++ b/RMStore/RMStore.h
@@ -30,6 +30,7 @@ extern NSString *const RMStoreErrorDomain;
 extern NSInteger const RMStoreErrorCodeDownloadCanceled;
 extern NSInteger const RMStoreErrorCodeUnknownProductIdentifier;
 extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
+extern NSString* const RMSKPaymentTransactionOrhanFinished;
 
 /** A StoreKit wrapper that adds blocks and notifications, plus optional receipt verification and purchase management.
  */

--- a/RMStore/RMStore.h
+++ b/RMStore/RMStore.h
@@ -31,19 +31,6 @@ extern NSInteger const RMStoreErrorCodeDownloadCanceled;
 extern NSInteger const RMStoreErrorCodeUnknownProductIdentifier;
 extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
 
-/**
- This gets posted globally when:
- Nobody has requested this transaction, which would indicate that the app has died after purchase (or at least sometime after beeing added) but before finishTransaction was called.
- This regularly happens on older devices if credit cards are denied or old, then the user needs to update their card info and switch away from the app. When coming back the app might have been killed and the success-block is gone (since it was living in RAM).
- */
-extern NSString* const RMSKPaymentTransactionOrphanFinished;
-
-///Same as RMSKPaymentTransactionOrphanFinished but for failed purchases.
-extern NSString* const RMSKPaymentTransactionOrphanFailed;
-
-///The key in the userInfo dictionary where the transaction can be found.
-extern NSString* const RMStoreNotificationTransaction;
-
 /** A StoreKit wrapper that adds blocks and notifications, plus optional receipt verification and purchase management.
  */
 @interface RMStore : NSObject<SKPaymentTransactionObserver>
@@ -274,6 +261,8 @@ extern NSString* const RMStoreNotificationTransaction;
 - (void)storeRefreshReceiptFinished:(NSNotification*)notification __attribute__((availability(ios,introduced=7.0)));
 - (void)storeRestoreTransactionsFailed:(NSNotification*)notification;
 - (void)storeRestoreTransactionsFinished:(NSNotification*)notification;
+- (void)storeTransactionsOrphanFinished:(NSNotification*)notification;
+- (void)storeTransactionsOrphanFailed:(NSNotification*)notification;
 
 @end
 

--- a/RMStore/RMStore.h
+++ b/RMStore/RMStore.h
@@ -36,10 +36,10 @@ extern NSInteger const RMStoreErrorCodeUnableToCompleteVerification;
  Nobody has requested this transaction, which would indicate that the app has died after purchase (or at least sometime after beeing added) but before finishTransaction was called.
  This regularly happens on older devices if credit cards are denied or old, then the user needs to update their card info and switch away from the app. When coming back the app might have been killed and the success-block is gone (since it was living in RAM).
  */
-extern NSString* const RMSKPaymentTransactionOrhanFinished;
+extern NSString* const RMSKPaymentTransactionOrphanFinished;
 
-///Same as RMSKPaymentTransactionOrhanFinished but for failed purchases.
-extern NSString* const RMSKPaymentTransactionOrhanFailed;
+///Same as RMSKPaymentTransactionOrphanFinished but for failed purchases.
+extern NSString* const RMSKPaymentTransactionOrphanFailed;
 
 /** A StoreKit wrapper that adds blocks and notifications, plus optional receipt verification and purchase management.
  */

--- a/RMStore/RMStore.h
+++ b/RMStore/RMStore.h
@@ -41,6 +41,9 @@ extern NSString* const RMSKPaymentTransactionOrphanFinished;
 ///Same as RMSKPaymentTransactionOrphanFinished but for failed purchases.
 extern NSString* const RMSKPaymentTransactionOrphanFailed;
 
+///The key in the userInfo dictionary where the transaction can be found.
+extern NSString* const RMStoreNotificationTransaction;
+
 /** A StoreKit wrapper that adds blocks and notifications, plus optional receipt verification and purchase management.
  */
 @interface RMStore : NSObject<SKPaymentTransactionObserver>

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -39,8 +39,8 @@ NSString* const RMSKRefreshReceiptFailed = @"RMSKRefreshReceiptFailed";
 NSString* const RMSKRefreshReceiptFinished = @"RMSKRefreshReceiptFinished";
 NSString* const RMSKRestoreTransactionsFailed = @"RMSKRestoreTransactionsFailed";
 NSString* const RMSKRestoreTransactionsFinished = @"RMSKRestoreTransactionsFinished";
-NSString* const RMSKPaymentTransactionOrhanFinished = @"RMSKPaymentTransactionOrhanFinished";
-NSString* const RMSKPaymentTransactionOrhanFailed = @"RMSKPaymentTransactionOrhanFailed";
+NSString* const RMSKPaymentTransactionOrphanFinished = @"RMSKPaymentTransactionOrphanFinished";
+NSString* const RMSKPaymentTransactionOrphanFailed = @"RMSKPaymentTransactionOrphanFailed";
 
 NSString* const RMStoreNotificationInvalidProductIdentifiers = @"invalidProductIdentifiers";
 NSString* const RMStoreNotificationDownloadProgress = @"downloadProgress";
@@ -561,7 +561,7 @@ typedef void (^RMStoreSuccessBlock)();
     }
 	else
 	{
-		[self postNotificationWithName:RMSKPaymentTransactionOrhanFailed transaction:transaction userInfoExtras:nil];
+		[self postNotificationWithName:RMSKPaymentTransactionOrphanFailed transaction:transaction userInfoExtras:nil];
 	}
     
     NSDictionary *extras = error ? @{RMStoreNotificationStoreError : error} : nil;
@@ -652,7 +652,7 @@ typedef void (^RMStoreSuccessBlock)();
 		 Nobody has requested this transaction, which would indicate that the app has died after purchase (or at least sometime after beeing added) but before finishTransaction was called.
 		 This regularly happens on older devices if credit cards are denied or old, then the user needs to update their card info and switch away from the app. When coming back the app might have been killed and the success-block is gone (since it was living in RAM).
 		 */
-		[self postNotificationWithName:RMSKPaymentTransactionOrhanFinished transaction:transaction userInfoExtras:nil];
+		[self postNotificationWithName:RMSKPaymentTransactionOrphanFinished transaction:transaction userInfoExtras:nil];
 	}
     
     [self postNotificationWithName:RMSKPaymentTransactionFinished transaction:transaction userInfoExtras:nil];

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -131,7 +131,8 @@ typedef void (^RMStoreSuccessBlock)();
 
 @end
 
-@implementation RMStore {
+@implementation RMStore
+{
     NSMutableDictionary *_addPaymentParameters; // HACK: We use a dictionary of product identifiers because the returned SKPayment is different from the one we add to the queue. Bad Apple.
     NSMutableDictionary *_products;
     NSMutableSet *_productsRequestDelegates;
@@ -295,7 +296,7 @@ typedef void (^RMStoreSuccessBlock)();
 {
     _refreshReceiptFailureBlock = failureBlock;
     _refreshReceiptSuccessBlock = successBlock;
-    _refreshReceiptRequest = [[SKReceiptRefreshRequest alloc] initWithReceiptProperties:@{}];
+	_refreshReceiptRequest = [[SKReceiptRefreshRequest alloc] initWithReceiptProperties:@{}];
     _refreshReceiptRequest.delegate = self;
     [_refreshReceiptRequest start];
 }
@@ -770,7 +771,7 @@ typedef void (^RMStoreSuccessBlock)();
     
     for (SKProduct *product in products)
     {
-        RMStoreLog(@"received product with id %@", product.productIdentifier);
+        //RMStoreLog(@"received product with id %@", product.productIdentifier);
         [self.store addProduct:product];
     }
     

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -334,6 +334,9 @@ typedef void (^RMStoreSuccessBlock)();
     [self addStoreObserver:observer selector:@selector(storeRefreshReceiptFinished:) notificationName:RMSKRefreshReceiptFinished];
     [self addStoreObserver:observer selector:@selector(storeRestoreTransactionsFailed:) notificationName:RMSKRestoreTransactionsFailed];
     [self addStoreObserver:observer selector:@selector(storeRestoreTransactionsFinished:) notificationName:RMSKRestoreTransactionsFinished];
+	[self addStoreObserver:observer selector:@selector(storeTransactionsOrphanFinished:) notificationName:RMSKPaymentTransactionOrphanFinished];
+	[self addStoreObserver:observer selector:@selector(storeTransactionsOrphanFailed:) notificationName:RMSKPaymentTransactionOrphanFailed];
+	
 }
 
 - (void)removeStoreObserver:(id<RMStoreObserver>)observer
@@ -352,6 +355,8 @@ typedef void (^RMStoreSuccessBlock)();
     [[NSNotificationCenter defaultCenter] removeObserver:observer name:RMSKRefreshReceiptFinished object:self];
     [[NSNotificationCenter defaultCenter] removeObserver:observer name:RMSKRestoreTransactionsFailed object:self];
     [[NSNotificationCenter defaultCenter] removeObserver:observer name:RMSKRestoreTransactionsFinished object:self];
+	[[NSNotificationCenter defaultCenter] removeObserver:observer name:RMSKPaymentTransactionOrphanFinished object:self];
+	[[NSNotificationCenter defaultCenter] removeObserver:observer name:RMSKPaymentTransactionOrphanFailed object:self];
 }
 
 // Private

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -39,6 +39,7 @@ NSString* const RMSKRefreshReceiptFailed = @"RMSKRefreshReceiptFailed";
 NSString* const RMSKRefreshReceiptFinished = @"RMSKRefreshReceiptFinished";
 NSString* const RMSKRestoreTransactionsFailed = @"RMSKRestoreTransactionsFailed";
 NSString* const RMSKRestoreTransactionsFinished = @"RMSKRestoreTransactionsFinished";
+NSString* const RMSKPaymentTransactionOrhanFinished = @"RMSKPaymentTransactionOrhanFinished";
 
 NSString* const RMStoreNotificationInvalidProductIdentifiers = @"invalidProductIdentifiers";
 NSString* const RMStoreNotificationDownloadProgress = @"downloadProgress";
@@ -640,6 +641,14 @@ typedef void (^RMStoreSuccessBlock)();
     {
         wrapper.successBlock(transaction);
     }
+	else
+	{
+		/*
+		 Nobody has requested this transaction, which would indicate that the app has died after purchase (or at least sometime after beeing added) but before finishTransaction was called.
+		 This regularly happens on older devices if credit cards are denied or old, then the user needs to update their card info and switch away from the app. When coming back the app might have been killed and the success-block is gone (since it was living in RAM).
+		 */
+		[self postNotificationWithName:RMSKPaymentTransactionOrhanFinished transaction:transaction userInfoExtras:nil];
+	}
     
     [self postNotificationWithName:RMSKPaymentTransactionFinished transaction:transaction userInfoExtras:nil];
     

--- a/RMStore/RMStore.m
+++ b/RMStore/RMStore.m
@@ -40,6 +40,7 @@ NSString* const RMSKRefreshReceiptFinished = @"RMSKRefreshReceiptFinished";
 NSString* const RMSKRestoreTransactionsFailed = @"RMSKRestoreTransactionsFailed";
 NSString* const RMSKRestoreTransactionsFinished = @"RMSKRestoreTransactionsFinished";
 NSString* const RMSKPaymentTransactionOrhanFinished = @"RMSKPaymentTransactionOrhanFinished";
+NSString* const RMSKPaymentTransactionOrhanFailed = @"RMSKPaymentTransactionOrhanFailed";
 
 NSString* const RMStoreNotificationInvalidProductIdentifiers = @"invalidProductIdentifiers";
 NSString* const RMStoreNotificationDownloadProgress = @"downloadProgress";
@@ -558,6 +559,10 @@ typedef void (^RMStoreSuccessBlock)();
     {
         parameters.failureBlock(transaction, error);
     }
+	else
+	{
+		[self postNotificationWithName:RMSKPaymentTransactionOrhanFailed transaction:transaction userInfoExtras:nil];
+	}
     
     NSDictionary *extras = error ? @{RMStoreNotificationStoreError : error} : nil;
     [self postNotificationWithName:RMSKPaymentTransactionFailed transaction:transaction userInfoExtras:extras];


### PR DESCRIPTION
This fixes a potential bug where the app dies before finishTransactions can be called. Then at next startup, RMStore will process transactions nobody has asked for and will just mark them as complete (since there will be no successBlock or failBlock to call).

This regularly happens on older devices if credit cards are denied or old, then the user needs to update their card info and switch away from the app (which then might be killed). Or the user just won't come back since filling out credit card info is such a hassle. When coming back (could be a week later), RMStore has nobody's block to call.
