### PR TITLE
A receipt contains an active auto renewable subscription for a produc…

### DIFF
--- a/RMStore/Optional/RMAppReceipt.m
+++ b/RMStore/Optional/RMAppReceipt.m
@@ -162,19 +162,12 @@ static NSURL *_appleRootCertificateURL = nil;
 
 -(BOOL)containsActiveAutoRenewableSubscriptionOfProductIdentifier:(NSString *)productIdentifier forDate:(NSDate *)date
 {
-    RMAppReceiptIAP *lastTransaction = nil;
-    
     for (RMAppReceiptIAP *iap in self.inAppPurchases)
     {
-        if (![iap.productIdentifier isEqualToString:productIdentifier]) continue;
-        
-        if (!lastTransaction || [iap.subscriptionExpirationDate compare:lastTransaction.subscriptionExpirationDate] == NSOrderedDescending)
-        {
-            lastTransaction = iap;
-        }
+        if ([iap.productIdentifier isEqualToString:productIdentifier] && [iap isActiveAutoRenewableSubscriptionForDate:date]) return YES;
     }
     
-    return [lastTransaction isActiveAutoRenewableSubscriptionForDate:date];
+    return NO;
 }
 
 - (BOOL)verifyReceiptHash


### PR DESCRIPTION
…t and a date if any transaction for the product is active for the date.

The prior code would give a false negative if the date being tested is within the subscription time frame of a transaction that is not the most recent transaction.
