### PR TITLE
Validate receipt using Apple Certificate data

### DIFF
--- a/RMStore/Optional/RMAppReceipt.h
+++ b/RMStore/Optional/RMAppReceipt.h
@@ -102,6 +102,12 @@ __attribute__((availability(ios,introduced=7.0)))
  */
 + (void)setAppleRootCertificateURL:(NSURL*)url;
 
+/**
+ Sets the data of the Apple Root certificate that will be used to verifiy the signature of the bundle receipt. This takes precedence over AppleRootCertificateURL if both are set. If none is provided, AppleRootCertificateURL will be used. If no certificate is available, no signature verification will be performed. 
+ @param data containing the Apple Root certificate.
+ */
++ (void)setAppleRootCertificateData:(NSData*)data;
+
 @end
 
 /** Represents an in-app purchase in the app receipt.

--- a/RMStore/Optional/RMAppReceipt.m
+++ b/RMStore/Optional/RMAppReceipt.m
@@ -103,6 +103,8 @@ static NSString* RMASN1ReadIA5SString(const uint8_t **pp, long omax)
 
 static NSURL *_appleRootCertificateURL = nil;
 
+static NSData *_appleRootCertificateData = nil;
+
 @implementation RMAppReceipt
 
 - (instancetype)initWithASN1Data:(NSData*)asn1Data
@@ -215,6 +217,11 @@ static NSURL *_appleRootCertificateURL = nil;
     _appleRootCertificateURL = url;
 }
 
++ (void)setAppleRootCertificateData:(NSData*)data
+{
+  _appleRootCertificateData = data;
+}
+
 #pragma mark - Utils
 
 + (NSData*)dataFromPCKS7Path:(NSString*)path
@@ -229,8 +236,13 @@ static NSURL *_appleRootCertificateURL = nil;
     if (!p7) return nil;
     
     NSData *data;
-    NSURL *certificateURL = _appleRootCertificateURL ? : [[NSBundle mainBundle] URLForResource:@"AppleIncRootCertificate" withExtension:@"cer"];
-    NSData *certificateData = [NSData dataWithContentsOfURL:certificateURL];
+    NSData *certificateData = _appleRootCertificateData;
+  
+    if( certificateData.length == 0 ) {
+        NSURL *certificateURL = _appleRootCertificateURL ? : [[NSBundle mainBundle] URLForResource:@"AppleIncRootCertificate" withExtension:@"cer"];
+        certificateData = [NSData dataWithContentsOfURL:certificateURL];
+    }
+  
     if (!certificateData || [self verifyPCKS7:p7 withCertificateData:certificateData])
     {
         struct pkcs7_st *contents = p7->d.sign->contents;


### PR DESCRIPTION
Adds a method to provide Apple's certificate data as an alternative to the certificate url.
This can be useful when Apple's certificate is embedded in the source code (base64) instead of being in the app's resources. It's specially useful in Mac Apps, where anyone could replace the certificate in the bundle.

This change does not affect setAppleRootCertificateURL. The receipt can still be validated with the url of the certificate, but if the certificate data exists, it takes precedence over the url.
