### PR TITLE
Update podspec:OpenSSL-Universal

### DIFF
--- a/RMStore.podspec
+++ b/RMStore.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
     arv.dependency 'RMStore/Core'
     arv.platform = :ios, '7.0'
     arv.source_files = 'RMStore/Optional/RMStoreAppReceiptVerifier.{h,m}', 'RMStore/Optional/RMAppReceipt.{h,m}'
-    arv.dependency 'OpenSSL', '~> 1.0'
+    arv.dependency 'OpenSSL-Universal', '~> 1.0'
   end
 
   s.subspec 'TransactionReceiptVerifier' do |trv|


### PR DESCRIPTION
Change dependency: from OpenSSL to OpenSSL-Universal
If we use "OpenSSL" as a dependency, an error will occur when running "pod install".
I suggest to change to OpenSSL-Universal!

I tested with my application on AppStore and it works perfect